### PR TITLE
Fix MapView to utilize full screen ignoring all safe areas

### DIFF
--- a/WhichWay/ContentView.swift
+++ b/WhichWay/ContentView.swift
@@ -41,7 +41,7 @@ struct ContentView: View {
     // MARK: - View Body
     
     var body: some View {
-        Group {
+        ZStack {
             switch appStateManager.state {
             case .loading, .error:
                 LoadingView(
@@ -57,6 +57,7 @@ struct ContentView: View {
                     .transition(.opacity)
             }
         }
+        .ignoresSafeArea(.all) // Ensure the entire container ignores safe areas
         .animation(.easeInOut(duration: 0.5), value: appStateManager.state)
         .onAppear {
             setupAppState()

--- a/WhichWay/Views/MapView.swift
+++ b/WhichWay/Views/MapView.swift
@@ -161,6 +161,9 @@ struct MapView: View {
             // }
         }
         .ignoresSafeArea(.all) // Complete full-screen map display
+        .edgesIgnoringSafeArea(.all) // Additional safe area ignoring for older iOS versions
+        .frame(maxWidth: .infinity, maxHeight: .infinity) // Ensure full width and height
+        .clipped() // Clip any content that might extend beyond bounds
         .sheet(isPresented: $showingStationDetail) {
             if let serviceInfo = stationServiceInfo {
                 StationDetailSheet(


### PR DESCRIPTION
- Modified ContentView to use ZStack instead of Group for better layout control
- Added .ignoresSafeArea(.all) to ContentView container
- Enhanced MapView with additional safe area modifiers
- Ensures MapView takes up entire device screen without respecting safe areas

🤖 Generated with [Claude Code](https://claude.ai/code)